### PR TITLE
Fix issue: Inefficient Memory Parameter

### DIFF
--- a/packages/contracts/contracts/MultiSigWallet.sol
+++ b/packages/contracts/contracts/MultiSigWallet.sol
@@ -200,7 +200,7 @@ contract MultiSigWallet is ERC165, IMultiSigWallet {
     }
 
     /// @dev Allows to change the metadata of wallet
-    function changeMetadata(string memory _name, string memory _description) public onlyWallet {
+    function changeMetadata(string calldata _name, string calldata _description) public onlyWallet {
         name = _name;
         description = _description;
     }


### PR DESCRIPTION
We recommend changing the parameter's data location to calldata to save gas.