### PR TITLE
Fix issue: Create is Depreciated due to Reorg Attack

### DIFF
--- a/packages/contracts/contracts/IMultiSigWalletFactory.sol
+++ b/packages/contracts/contracts/IMultiSigWalletFactory.sol
@@ -18,6 +18,7 @@ interface IMultiSigWalletFactory is IERC165 {
         address[] memory _owners,
         uint256 _required
     ) external returns (address);
+    function register(address payable _wallet) external;
     function getNumberOfWalletsForCreator(address _creator) external view returns (uint256);
     function getWalletsForCreator(
         address _creator,

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "multisig-wallet-contracts",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "Smart Contracts of MultiSignature Wallet",
     "files": [
         "**/*.sol"

--- a/packages/contracts/test/Factory.test.ts
+++ b/packages/contracts/test/Factory.test.ts
@@ -35,9 +35,10 @@ async function deployMultiSigWallet(
         "wallet"
     );
 
-    if (address !== undefined)
+    if (address !== undefined) {
+        await factoryContract.register(address);
         return (await ethers.getContractFactory("MultiSigWallet")).attach(address) as MultiSigWallet;
-    else return undefined;
+    } else return undefined;
 }
 
 describe("Test for MultiSigWalletFactory", () => {

--- a/packages/contracts/test/MultiSigToken.test.ts
+++ b/packages/contracts/test/MultiSigToken.test.ts
@@ -37,9 +37,10 @@ async function deployMultiSigWallet(
         "wallet"
     );
 
-    return address !== undefined
-        ? ((await ethers.getContractFactory("MultiSigWallet")).attach(address) as MultiSigWallet)
-        : undefined;
+    if (address !== undefined) {
+        await factoryContract.register(address);
+        return (await ethers.getContractFactory("MultiSigWallet")).attach(address) as MultiSigWallet;
+    } else return undefined;
 }
 
 async function deployToken(deployer: Wallet, owner: string): Promise<MultiSigToken> {

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -1,6 +1,6 @@
 {
     "name": "multisig-wallet-contracts-lib",
-    "version": "1.1.1",
+    "version": "1.1.2",
 
     "description": "",
     "main": "dist/bundle-cjs.js",


### PR DESCRIPTION
Scenario
Consider the following scenario as an example:

Alice calls create to deploy a MultiSigWallet contract.
Due to potential block reorg, Bob can call create to deploy a new MultiSigWallet contract with the same address in Step 1.
Alice, who does not notice the block reorg, sends funds to the address in Step 1.
Bob's contract finally receives the funds.
Recommendation
Deploy the contract via create2 with salt that includes msg.sender or other unique information or inform users to wait for N confirmations before taking the next step.