### PR TITLE
Improve a function `MultiSigWalletFactory.create()`

### DIFF
--- a/packages/contracts/contracts/IMultiSigWalletFactory.sol
+++ b/packages/contracts/contracts/IMultiSigWalletFactory.sol
@@ -16,7 +16,8 @@ interface IMultiSigWalletFactory is IERC165 {
         string calldata _name,
         string calldata _description,
         address[] memory _owners,
-        uint256 _required
+        uint256 _required,
+        uint256 _seed
     ) external returns (address);
     function getNumberOfWalletsForCreator(address _creator) external view returns (uint256);
     function getWalletsForCreator(

--- a/packages/contracts/contracts/MultiSigWallet.sol
+++ b/packages/contracts/contracts/MultiSigWallet.sol
@@ -44,6 +44,7 @@ contract MultiSigWallet is ERC165, IMultiSigWallet {
     uint256 internal required;
     uint256 internal transactionCount;
     address internal factoryAddress;
+    bool internal initialized;
 
     /*
      *  Modifiers
@@ -93,6 +94,10 @@ contract MultiSigWallet is ERC165, IMultiSigWallet {
         _;
     }
 
+    constructor() {
+        initialized = false;
+    }
+
     /*
      * Public functions
      */
@@ -104,6 +109,8 @@ contract MultiSigWallet is ERC165, IMultiSigWallet {
         address[] memory _members,
         uint256 _required
     ) public {
+        require(!initialized, "Already initialized");
+        require(msg.sender == _factory, "Sender is not authorized");
         require(
             _members.length <= MAX_OWNER_COUNT && _required <= _members.length && _required != 0 && _members.length != 0
         );
@@ -120,6 +127,7 @@ contract MultiSigWallet is ERC165, IMultiSigWallet {
             members.push(_members[i]);
         }
         required = _required;
+        initialized = true;
     }
 
     /**

--- a/packages/contracts/contracts/MultiSigWallet.sol
+++ b/packages/contracts/contracts/MultiSigWallet.sol
@@ -7,7 +7,7 @@ import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import "./IMultiSigWallet.sol";
 import "./IMultiSigWalletFactory.sol";
 
-/// @title Multisignature wallet - Allows multiple parties to agree on transactions before execution.
+/// @title Multi-Signature wallet - Allows multiple parties to agree on transactions before execution.
 /// @author Stefan George - <stefan.george@consensys.net>
 contract MultiSigWallet is ERC165, IMultiSigWallet {
     /*
@@ -34,8 +34,8 @@ contract MultiSigWallet is ERC165, IMultiSigWallet {
      */
     string public override name;
     string public override description;
-    address public override creator;
-    uint256 public override createdTime;
+    address public immutable override creator;
+    uint256 public immutable override createdTime;
 
     mapping(uint256 => Transaction) internal transactions;
     mapping(uint256 => mapping(address => bool)) internal confirmations;
@@ -43,8 +43,7 @@ contract MultiSigWallet is ERC165, IMultiSigWallet {
     address[] internal members;
     uint256 internal required;
     uint256 internal transactionCount;
-    address internal factoryAddress;
-    bool internal initialized;
+    address internal immutable factoryAddress;
 
     /*
      *  Modifiers
@@ -94,23 +93,14 @@ contract MultiSigWallet is ERC165, IMultiSigWallet {
         _;
     }
 
-    constructor() {
-        initialized = false;
-    }
-
-    /*
-     * Public functions
-     */
-    function initialize(
+    constructor(
         address _factory,
         string memory _name,
         string memory _description,
         address _creator,
         address[] memory _members,
         uint256 _required
-    ) public {
-        require(!initialized, "Already initialized");
-        require(msg.sender == _factory, "Sender is not authorized");
+    ) {
         require(
             _members.length <= MAX_OWNER_COUNT && _required <= _members.length && _required != 0 && _members.length != 0
         );
@@ -127,7 +117,6 @@ contract MultiSigWallet is ERC165, IMultiSigWallet {
             members.push(_members[i]);
         }
         required = _required;
-        initialized = true;
     }
 
     /**

--- a/packages/contracts/contracts/MultiSigWalletFactory.sol
+++ b/packages/contracts/contracts/MultiSigWalletFactory.sol
@@ -38,23 +38,12 @@ contract MultiSigWalletFactory is ERC165, IMultiSigWalletFactory {
         uint256 _required
     ) external override returns (address) {
         bytes32 salt = keccak256(abi.encodePacked(msg.sender, block.number));
-        address wallet;
-        assembly {
-            let size := calldatasize()
-            let data := mload(0x40)
-            mstore(0x40, add(data, size))
-            mstore(data, size)
-            calldatacopy(add(data, 0x20), 0, size)
-            salt := keccak256(add(data, 0x20), size)
-            wallet := create2(0, data, size, salt)
-        }
-        require(wallet != address(0), "Failed to create wallet");
-
         MultiSigWallet walletContract;
         bytes memory bytecode = type(MultiSigWallet).creationCode;
         assembly {
             walletContract := create2(0, add(bytecode, 0x20), mload(bytecode), salt)
         }
+        require(address(walletContract) != address(0), "Failed to create wallet");
         address walletAddress = address(walletContract);
 
         // 생성된 월렛 초기화 및 멤버 추가

--- a/packages/contracts/contracts/MultiSigWalletFactory.sol
+++ b/packages/contracts/contracts/MultiSigWalletFactory.sol
@@ -30,14 +30,16 @@ contract MultiSigWalletFactory is ERC165, IMultiSigWalletFactory {
     /// @param _description Description of multi-signature wallet.
     /// @param _members List of initial members.
     /// @param _required Number of required confirmations.
+    /// @param _seed Used to calculate a salt when creating a contract
     /// @return wallet address.
     function create(
         string calldata _name,
         string calldata _description,
         address[] memory _members,
-        uint256 _required
+        uint256 _required,
+        uint256 _seed
     ) external override returns (address) {
-        bytes32 salt = keccak256(abi.encodePacked(msg.sender, block.number));
+        bytes32 salt = keccak256(abi.encodePacked(msg.sender, _seed));
         MultiSigWallet walletContract;
         bytes memory bytecode = type(MultiSigWallet).creationCode;
         assembly {

--- a/packages/contracts/contracts/MultiSigWalletFactory.sol
+++ b/packages/contracts/contracts/MultiSigWalletFactory.sol
@@ -40,19 +40,20 @@ contract MultiSigWalletFactory is ERC165, IMultiSigWalletFactory {
         uint256 _seed
     ) external override returns (address) {
         bytes32 salt = keccak256(abi.encodePacked(msg.sender, _seed));
-        MultiSigWallet walletContract;
-        bytes memory bytecode = type(MultiSigWallet).creationCode;
-        assembly {
-            walletContract := create2(0, add(bytecode, 0x20), mload(bytecode), salt)
-        }
-        require(address(walletContract) != address(0), "Failed to create wallet");
+        MultiSigWallet walletContract = new MultiSigWallet{ salt: salt }(
+            address(this),
+            _name,
+            _description,
+            msg.sender,
+            _members,
+            _required
+        );
         address walletAddress = address(walletContract);
 
-        // 생성된 월렛 초기화 및 멤버 추가
-        walletContract.initialize(address(this), _name, _description, msg.sender, _members, _required);
         for (uint256 idx = 0; idx < _members.length; idx++) {
             _addMember(_members[idx], walletAddress);
         }
+
         register(walletAddress);
 
         return walletAddress;

--- a/packages/contracts/test/ExecutionAfterRequirementsChanged.test.ts
+++ b/packages/contracts/test/ExecutionAfterRequirementsChanged.test.ts
@@ -5,57 +5,83 @@ import { ethers } from "hardhat";
 import { HardhatAccount } from "../src/HardhatAccount";
 import { BOACoin } from "../src/utils/Amount";
 import { ContractUtils } from "../src/utils/ContractUtils";
-import { MultiSigWallet } from "../typechain-types";
+import { MultiSigWallet, MultiSigWalletFactory } from "../typechain-types";
 
 import assert from "assert";
 import { BigNumber, Wallet } from "ethers";
 
-import { AddressZero } from "@ethersproject/constants";
-
-async function deployMultiSigWallet(deployer: Wallet, owners: string[], required: number): Promise<MultiSigWallet> {
-    const factory = await ethers.getContractFactory("MultiSigWallet");
-    const contract = (await factory.connect(deployer).deploy()) as MultiSigWallet;
+async function deployMultiSigWalletFactory(deployer: Wallet): Promise<MultiSigWalletFactory> {
+    const factory = await ethers.getContractFactory("MultiSigWalletFactory");
+    const contract = (await factory.connect(deployer).deploy()) as MultiSigWalletFactory;
     await contract.deployed();
     await contract.deployTransaction.wait();
-    await contract.initialize(AddressZero, "name", "description", deployer.address, owners, required);
     return contract;
 }
 
+async function deployMultiSigWallet(
+    factoryAddress: string,
+    deployer: Wallet,
+    owners: string[],
+    required: number
+): Promise<MultiSigWallet | undefined> {
+    const contractFactory = await ethers.getContractFactory("MultiSigWalletFactory");
+    const factoryContract = contractFactory.attach(factoryAddress) as MultiSigWalletFactory;
+
+    const address = await ContractUtils.getEventValueString(
+        await factoryContract.connect(deployer).create("name", "description", owners, required),
+        factoryContract.interface,
+        "ContractInstantiation",
+        "wallet"
+    );
+
+    if (address !== undefined) {
+        return (await ethers.getContractFactory("MultiSigWallet")).attach(address) as MultiSigWallet;
+    } else return undefined;
+}
+
 describe("MultiSigWallet", () => {
-    let multisigInstance: MultiSigWallet;
+    let multiSigFactory: MultiSigWalletFactory;
+    let multiSigWallet: MultiSigWallet | undefined;
     const requiredConfirmations = 2;
     const provider = ethers.provider;
     const raws = HardhatAccount.keys.map((m) => new Wallet(m, ethers.provider));
-    const [deployer, owner0, owner1, owner2, owner3, account0, account1, account2] = raws;
+    const [deployer, owner0, owner1, owner2, owner3] = raws;
     const owners = [owner0, owner1, owner2];
-    const accounts = [account0, account1, account2];
 
     before(async () => {
-        multisigInstance = await deployMultiSigWallet(
+        multiSigFactory = await deployMultiSigWalletFactory(deployer);
+        assert.ok(multiSigFactory);
+    });
+
+    before(async () => {
+        multiSigWallet = await deployMultiSigWallet(
+            multiSigFactory.address,
             deployer,
             owners.map((m) => m.address),
             requiredConfirmations
         );
-        assert.ok(multisigInstance);
+        assert.ok(multiSigWallet);
     });
 
     it("test execution after requirements changed", async () => {
+        assert.ok(multiSigWallet);
+
         const deposit = BOACoin.make("100").value;
 
         await deployer.sendTransaction({
-            to: multisigInstance.address,
+            to: multiSigWallet.address,
             value: deposit,
         });
-        const balance = await provider.getBalance(multisigInstance.address);
+        const balance = await provider.getBalance(multiSigWallet.address);
         assert.deepStrictEqual(balance.valueOf(), deposit);
 
         // Add owner wa_4
-        const addOwnerData = multisigInstance.interface.encodeFunctionData("addMember", [owner3.address]);
+        const addOwnerData = multiSigWallet.interface.encodeFunctionData("addMember", [owner3.address]);
         const transactionId = await ContractUtils.getEventValueBigNumber(
-            await multisigInstance
+            await multiSigWallet
                 .connect(owners[0])
-                .submitTransaction("title", "description", multisigInstance.address, 0, addOwnerData),
-            multisigInstance.interface,
+                .submitTransaction("title", "description", multiSigWallet.address, 0, addOwnerData),
+            multiSigWallet.interface,
             "Submission",
             "transactionId"
         );
@@ -67,43 +93,43 @@ describe("MultiSigWallet", () => {
         const excludeExecuted = false;
         const includeExecuted = true;
         assert.deepStrictEqual(
-            await multisigInstance.getTransactionIdsInCondition(0, 1, includePending, excludeExecuted),
+            await multiSigWallet.getTransactionIdsInCondition(0, 1, includePending, excludeExecuted),
             [BigNumber.from(transactionId)]
         );
 
         // Update required to 1
         const newRequired = 1;
-        const updateRequirementData = multisigInstance.interface.encodeFunctionData("changeRequirement", [newRequired]);
+        const updateRequirementData = multiSigWallet.interface.encodeFunctionData("changeRequirement", [newRequired]);
 
         // Submit successfully
         const transactionId2 = await ContractUtils.getEventValueBigNumber(
-            await multisigInstance
+            await multiSigWallet
                 .connect(owners[0])
-                .submitTransaction("title", "description", multisigInstance.address, 0, updateRequirementData),
-            multisigInstance.interface,
+                .submitTransaction("title", "description", multiSigWallet.address, 0, updateRequirementData),
+            multiSigWallet.interface,
             "Submission",
             "transactionId"
         );
         assert.ok(transactionId2 !== undefined);
 
         assert.deepStrictEqual(
-            await multisigInstance.getTransactionIdsInCondition(0, 2, includePending, excludeExecuted),
+            await multiSigWallet.getTransactionIdsInCondition(0, 2, includePending, excludeExecuted),
             [BigNumber.from(transactionId), BigNumber.from(transactionId2)]
         );
 
         // Confirm change requirement transaction
-        const tx1 = await multisigInstance.connect(owners[1]).confirmTransaction(transactionId2);
+        const tx1 = await multiSigWallet.connect(owners[1]).confirmTransaction(transactionId2);
         await tx1.wait();
-        assert.equal((await multisigInstance.getRequired()).toNumber(), newRequired);
+        assert.equal((await multiSigWallet.getRequired()).toNumber(), newRequired);
         assert.deepStrictEqual(
-            await multisigInstance.getTransactionIdsInCondition(0, 2, excludePending, includeExecuted),
+            await multiSigWallet.getTransactionIdsInCondition(0, 2, excludePending, includeExecuted),
             [BigNumber.from(transactionId2)]
         );
 
-        const tx2 = await multisigInstance.connect(owners[0]).executeTransaction(transactionId);
+        const tx2 = await multiSigWallet.connect(owners[0]).executeTransaction(transactionId);
         await tx2.wait();
         assert.deepStrictEqual(
-            await multisigInstance.getTransactionIdsInCondition(0, 2, excludePending, includeExecuted),
+            await multiSigWallet.getTransactionIdsInCondition(0, 2, excludePending, includeExecuted),
             [BigNumber.from(transactionId), BigNumber.from(transactionId2)]
         );
     });

--- a/packages/contracts/test/ExecutionAfterRequirementsChanged.test.ts
+++ b/packages/contracts/test/ExecutionAfterRequirementsChanged.test.ts
@@ -22,13 +22,14 @@ async function deployMultiSigWallet(
     factoryAddress: string,
     deployer: Wallet,
     owners: string[],
-    required: number
+    required: number,
+    seed: BigNumber
 ): Promise<MultiSigWallet | undefined> {
     const contractFactory = await ethers.getContractFactory("MultiSigWalletFactory");
     const factoryContract = contractFactory.attach(factoryAddress) as MultiSigWalletFactory;
 
     const address = await ContractUtils.getEventValueString(
-        await factoryContract.connect(deployer).create("name", "description", owners, required),
+        await factoryContract.connect(deployer).create("name", "description", owners, required, seed),
         factoryContract.interface,
         "ContractInstantiation",
         "wallet"
@@ -58,7 +59,8 @@ describe("MultiSigWallet", () => {
             multiSigFactory.address,
             deployer,
             owners.map((m) => m.address),
-            requiredConfirmations
+            requiredConfirmations,
+            BigNumber.from(1)
         );
         assert.ok(multiSigWallet);
     });

--- a/packages/contracts/test/ExternalCalls.test.ts
+++ b/packages/contracts/test/ExternalCalls.test.ts
@@ -12,10 +12,11 @@ import { BigNumber, Wallet } from "ethers";
 
 async function deployMultiSigWallet(deployer: Wallet, owners: string[], required: number): Promise<MultiSigWallet> {
     const factory = await ethers.getContractFactory("MultiSigWallet");
-    const contract = (await factory.connect(deployer).deploy()) as MultiSigWallet;
+    const contract = (await factory
+        .connect(deployer)
+        .deploy(deployer.address, "name", "description", deployer.address, owners, required)) as MultiSigWallet;
     await contract.deployed();
     await contract.deployTransaction.wait();
-    await contract.initialize(deployer.address, "name", "description", deployer.address, owners, required);
     return contract;
 }
 

--- a/packages/contracts/test/ExternalCalls.test.ts
+++ b/packages/contracts/test/ExternalCalls.test.ts
@@ -10,14 +10,12 @@ import { MultiSigWallet, TestCalls, TestToken } from "../typechain-types";
 import assert from "assert";
 import { BigNumber, Wallet } from "ethers";
 
-import { AddressZero } from "@ethersproject/constants";
-
 async function deployMultiSigWallet(deployer: Wallet, owners: string[], required: number): Promise<MultiSigWallet> {
     const factory = await ethers.getContractFactory("MultiSigWallet");
     const contract = (await factory.connect(deployer).deploy()) as MultiSigWallet;
     await contract.deployed();
     await contract.deployTransaction.wait();
-    await contract.initialize(AddressZero, "name", "description", deployer.address, owners, required);
+    await contract.initialize(deployer.address, "name", "description", deployer.address, owners, required);
     return contract;
 }
 

--- a/packages/contracts/test/Factory.test.ts
+++ b/packages/contracts/test/Factory.test.ts
@@ -23,13 +23,16 @@ async function deployMultiSigWallet(
     name: string,
     description: string,
     owners: string[],
-    required: number
+    required: number,
+    seed: BigNumber
 ): Promise<MultiSigWallet | undefined> {
     const contractFactory = await ethers.getContractFactory("MultiSigWalletFactory");
     const factoryContract = contractFactory.attach(factoryAddress) as MultiSigWalletFactory;
 
     const address = await ContractUtils.getEventValueString(
-        await factoryContract.connect(deployer).create(name, description, owners, required, { gasLimit: 4000000 }),
+        await factoryContract
+            .connect(deployer)
+            .create(name, description, owners, required, seed, { gasLimit: 4000000 }),
         factoryContract.interface,
         "ContractInstantiation",
         "wallet"
@@ -84,7 +87,8 @@ describe("Test for MultiSigWalletFactory", () => {
             walletInfos[0].name,
             walletInfos[0].description,
             owners1.map((m) => m.address),
-            requiredConfirmations
+            requiredConfirmations,
+            BigNumber.from(1)
         );
         assert.ok(multiSigWallet1);
         assert.deepStrictEqual(await multiSigFactory.getNumberOfWalletsForMember(account0.address), BigNumber.from(1));
@@ -97,7 +101,8 @@ describe("Test for MultiSigWalletFactory", () => {
             walletInfos[1].name,
             walletInfos[1].description,
             owners2.map((m) => m.address),
-            requiredConfirmations
+            requiredConfirmations,
+            BigNumber.from(2)
         );
         assert.ok(multiSigWallet2);
         assert.deepStrictEqual(await multiSigFactory.getNumberOfWalletsForMember(account3.address), BigNumber.from(1));
@@ -110,7 +115,8 @@ describe("Test for MultiSigWalletFactory", () => {
             walletInfos[2].name,
             walletInfos[2].description,
             owners3.map((m) => m.address),
-            requiredConfirmations
+            requiredConfirmations,
+            BigNumber.from(3)
         );
         assert.ok(multiSigWallet3);
         assert.deepStrictEqual(await multiSigFactory.getNumberOfWalletsForMember(account0.address), BigNumber.from(2));
@@ -305,7 +311,8 @@ describe("Test for MultiSigWalletFactory 2", () => {
             walletInfos[0].name,
             walletInfos[0].description,
             members.map((m) => m.address),
-            requiredConfirmations
+            requiredConfirmations,
+            BigNumber.from(10)
         );
         assert.ok(multiSigWallet1);
         assert.deepStrictEqual(
@@ -393,7 +400,8 @@ describe("Test for MultiSigWalletFactory 3", () => {
             walletInfos[0].name,
             walletInfos[0].description,
             members.map((m) => m.address),
-            requiredConfirmations
+            requiredConfirmations,
+            BigNumber.from(20)
         );
         assert.ok(multiSigWallet1);
         assert.deepStrictEqual(

--- a/packages/contracts/test/MultiSigToken.test.ts
+++ b/packages/contracts/test/MultiSigToken.test.ts
@@ -25,13 +25,14 @@ async function deployMultiSigWallet(
     name: string,
     description: string,
     owners: string[],
-    required: number
+    required: number,
+    seed: BigNumber
 ): Promise<MultiSigWallet | undefined> {
     const contractFactory = await ethers.getContractFactory("MultiSigWalletFactory");
     const factoryContract = contractFactory.attach(factoryAddress) as MultiSigWalletFactory;
 
     const address = await ContractUtils.getEventValueString(
-        await factoryContract.connect(deployer).create(name, description, owners, required),
+        await factoryContract.connect(deployer).create(name, description, owners, required, seed),
         factoryContract.interface,
         "ContractInstantiation",
         "wallet"
@@ -72,7 +73,8 @@ describe("Test for MultiSigWalletFactory", () => {
             "My Wallet 1",
             "My first multi-sign wallet",
             owners1.map((m) => m.address),
-            requiredConfirmations
+            requiredConfirmations,
+            BigNumber.from(1)
         );
         assert.ok(multiSigWallet);
 
@@ -208,7 +210,8 @@ describe("Test for MultiSigWalletFactory 2", () => {
             "My Wallet 1",
             "My first multi-sign wallet",
             owners1.map((m) => m.address),
-            requiredConfirmations
+            requiredConfirmations,
+            BigNumber.from(11)
         );
         assert.ok(multiSigWallet);
 

--- a/packages/contracts/test/SubmitTransaction.test.ts
+++ b/packages/contracts/test/SubmitTransaction.test.ts
@@ -23,13 +23,14 @@ async function deployMultiSigWallet(
     name: string,
     description: string,
     owners: string[],
-    required: number
+    required: number,
+    seed: BigNumber
 ): Promise<MultiSigWallet | undefined> {
     const contractFactory = await ethers.getContractFactory("MultiSigWalletFactory");
     const factoryContract = contractFactory.attach(factoryAddress) as MultiSigWalletFactory;
 
     const address = await ContractUtils.getEventValueString(
-        await factoryContract.connect(deployer).create(name, description, owners, required),
+        await factoryContract.connect(deployer).create(name, description, owners, required, seed),
         factoryContract.interface,
         "ContractInstantiation",
         "wallet"
@@ -65,7 +66,8 @@ describe("Test for SubmitTransaction - filter factoryAddress, IMultiSigWalletFac
             "My Wallet 1",
             "My first multi-sign wallet",
             owners1.map((m) => m.address),
-            requiredConfirmations
+            requiredConfirmations,
+            BigNumber.from(1)
         );
         assert.ok(multiSigWallet0);
 
@@ -86,7 +88,8 @@ describe("Test for SubmitTransaction - filter factoryAddress, IMultiSigWalletFac
             "My Wallet 1",
             "My first multi-sign wallet",
             owners1.map((m) => m.address),
-            requiredConfirmations
+            requiredConfirmations,
+            BigNumber.from(2)
         );
         assert.ok(multiSigWallet1);
 


### PR DESCRIPTION
1. There is no access control in the initialize function of the MultiSigWallet contract, which allows anyone to reinitialize the contract with arbitrary input.
    function initialize(
        address _factory,
        string memory _name,
        string memory _description,
        address _creator,
        address[] memory _members,
        uint256 _required
    ) public {
       ...
    }

2. The first create2 operation in the create function is redundant since it will deploy a meaningless with the bytecode based on the calldata to the create function.

3. The salt parameter used in the creation of a MultiSigWallet contract can be influenced by the block.number at the time of deployment. It is possible that Alice was unable to recover her wallet after a chain reorganization because the block.number had changed since the initial deployment of the contract. As a result, the wallet address associated with the contract may not be the same as the one to which Alice sent her funds.
We recommend the team revert to using the constructor function to initialize the MultiSigWallet. Actually, the official documents of Solidity (https://docs.soliditylang.org/en/v0.8.2/control-structures.html#salted-contract-creations-create2) provide a tutorial for deploying the contract with the create2 opcode by using the new keyword.

4. Additionally, we recommend that the team use msg.sender along with a user-assigned value to calculate the salt. This user-assigned value, seed, can enable one account to create multiple wallets.