### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/packages/contracts/contracts/MultiSigWallet.sol
+++ b/packages/contracts/contracts/MultiSigWallet.sol
@@ -211,24 +211,7 @@ contract MultiSigWallet is ERC165, IMultiSigWallet {
         uint256 _value,
         bytes calldata _data
     ) external override {
-        // Check if destination is MultiSigWalletFactory
         require(_destination != factoryAddress, "Invalid destination");
-
-        if (_data.length >= 4) {
-            // Get the first 4 bytes of _data
-            bytes4 selector;
-            assembly {
-                // Load the first 4 bytes of _data (the selector) into the selector variable
-                selector := calldataload(add(_data.offset, 0))
-            }
-
-            // Check if data is not calling addMember or removeMember function of MultiSigWalletFactory
-            require(
-                selector != IMultiSigWalletFactory.addMember.selector &&
-                    selector != IMultiSigWalletFactory.removeMember.selector,
-                "Invalid function call"
-            );
-        }
 
         uint256 transactionId = addTransaction(_title, _description, _destination, _value, _data);
         _confirmTransaction(transactionId);

--- a/packages/contracts/test/SubmitTransaction.test.ts
+++ b/packages/contracts/test/SubmitTransaction.test.ts
@@ -46,22 +46,18 @@ describe("Test for SubmitTransaction - filter factoryAddress, IMultiSigWalletFac
     const [deployer, account0, account1, account2, account3, account4] = raws;
     const owners1 = [account0, account1, account2];
 
-    let multiSigFactory0: MultiSigWalletFactory;
-    let multiSigFactory1: MultiSigWalletFactory;
-    let multiSigWallet0: MultiSigWallet | undefined;
-    let multiSigWallet1: MultiSigWallet | undefined;
+    let multiSigFactory: MultiSigWalletFactory;
+    let multiSigWallet: MultiSigWallet | undefined;
     const requiredConfirmations = 2;
 
     before(async () => {
-        multiSigFactory0 = await deployMultiSigWalletFactory(deployer);
-        assert.ok(multiSigFactory0);
-        multiSigFactory1 = await deployMultiSigWalletFactory(deployer);
-        assert.ok(multiSigFactory1);
+        multiSigFactory = await deployMultiSigWalletFactory(deployer);
+        assert.ok(multiSigFactory);
     });
 
     it("Create Wallet 0 by Factory 0", async () => {
-        multiSigWallet0 = await deployMultiSigWallet(
-            multiSigFactory0.address,
+        multiSigWallet = await deployMultiSigWallet(
+            multiSigFactory.address,
             deployer,
             "My Wallet 1",
             "My first multi-sign wallet",
@@ -69,86 +65,55 @@ describe("Test for SubmitTransaction - filter factoryAddress, IMultiSigWalletFac
             requiredConfirmations,
             BigNumber.from(1)
         );
-        assert.ok(multiSigWallet0);
+        assert.ok(multiSigWallet);
 
         assert.deepStrictEqual(
-            await multiSigWallet0.getMembers(),
+            await multiSigWallet.getMembers(),
             owners1.map((m) => m.address)
         );
 
-        assert.deepStrictEqual(await multiSigFactory0.getNumberOfWalletsForMember(account0.address), BigNumber.from(1));
-        assert.deepStrictEqual(await multiSigFactory0.getNumberOfWalletsForMember(account1.address), BigNumber.from(1));
-        assert.deepStrictEqual(await multiSigFactory0.getNumberOfWalletsForMember(account2.address), BigNumber.from(1));
+        assert.deepStrictEqual(await multiSigFactory.getNumberOfWalletsForMember(account0.address), BigNumber.from(1));
+        assert.deepStrictEqual(await multiSigFactory.getNumberOfWalletsForMember(account1.address), BigNumber.from(1));
+        assert.deepStrictEqual(await multiSigFactory.getNumberOfWalletsForMember(account2.address), BigNumber.from(1));
     });
 
-    it("Create Wallet 1 by Factory 1", async () => {
-        multiSigWallet1 = await deployMultiSigWallet(
-            multiSigFactory1.address,
-            deployer,
-            "My Wallet 1",
-            "My first multi-sign wallet",
-            owners1.map((m) => m.address),
-            requiredConfirmations,
-            BigNumber.from(2)
-        );
-        assert.ok(multiSigWallet1);
+    it("should reject addMember function call", async () => {
+        assert.ok(multiSigWallet);
 
-        assert.deepStrictEqual(
-            await multiSigWallet1.getMembers(),
-            owners1.map((m) => m.address)
-        );
-
-        assert.deepStrictEqual(await multiSigFactory1.getNumberOfWalletsForMember(account0.address), BigNumber.from(1));
-        assert.deepStrictEqual(await multiSigFactory1.getNumberOfWalletsForMember(account1.address), BigNumber.from(1));
-        assert.deepStrictEqual(await multiSigFactory1.getNumberOfWalletsForMember(account2.address), BigNumber.from(1));
-    });
-
-    it("should reject transaction to factory address", async () => {
-        assert.ok(multiSigWallet0);
+        const addMemberData = multiSigFactory.interface.encodeFunctionData("addMember", [
+            account3.address,
+            multiSigWallet.address,
+        ]);
 
         await assert.rejects(
-            multiSigWallet0.submitTransaction("Test Title", "Test Description", multiSigFactory0.address, 0, "0x"),
+            multiSigWallet.submitTransaction(
+                "Test Title",
+                "Test Description",
+                multiSigFactory.address,
+                0,
+                addMemberData
+            ),
             "Invalid destination"
         );
     });
 
-    it("should reject addMember function call", async () => {
-        assert.ok(multiSigWallet0);
-
-        const addMemberData = multiSigFactory0.interface.encodeFunctionData("addMember", [
-            account3.address,
-            multiSigWallet0.address,
-        ]);
-
-        await assert.rejects(
-            multiSigWallet0.submitTransaction(
-                "Test Title",
-                "Test Description",
-                multiSigFactory1.address,
-                0,
-                addMemberData
-            ),
-            "Invalid function call"
-        );
-    });
-
     it("should reject removeMember function call", async () => {
-        assert.ok(multiSigWallet0);
+        assert.ok(multiSigWallet);
 
-        const addMemberData = multiSigFactory0.interface.encodeFunctionData("removeMember", [
+        const addMemberData = multiSigFactory.interface.encodeFunctionData("removeMember", [
             account3.address,
-            multiSigWallet0.address,
+            multiSigWallet.address,
         ]);
 
         await assert.rejects(
-            multiSigWallet0.submitTransaction(
+            multiSigWallet.submitTransaction(
                 "Test Title",
                 "Test Description",
-                multiSigFactory1.address,
+                multiSigFactory.address,
                 0,
                 addMemberData
             ),
-            "Invalid function call"
+            "Invalid destination"
         );
     });
 });


### PR DESCRIPTION
MultiSigWallet contract is designed not to call any functions from its factory contract.

However, the current implementation prevents the MultiSigWallet contract from calling the addMember and removeMember functions on any contract other than the factory contract that created it. This restriction poses a problem in the following example scenario:

Wallet X is created by Factory A.
Wallet X wants to invoke addMmember function in contract B (assume the function id is the same).
In this case, when Wallet X tries to call the addMember or removeMember function on contract B, the transaction will be blocked because the function selector is disabled.

As a result, if the team is intended to not allow MultiSigWallet contract to invoke any function in its factory, the following function selector filter can be removed. And only keep _destination != factoryAddress validation.

        if (_data.length >= 4) {
...
            require(
                selector != IMultiSigWalletFactory.addMember.selector &&
                    selector != IMultiSigWalletFactory.removeMember.selector,
                "Invalid function call"
            );
        }
And If the design above is not intended, the validation should be:

Block the invocation when the destination address is factoryAddress and the function selector matches addMember.
Block the invocation when the destination address is factoryAddress and the function selector matches removeMember.
Which will allow the wallet contract to invoke other functionality such as Create in its factory contract.